### PR TITLE
feat: implement task crud operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,15 @@ mvn install
     The API should be running on http://localhost:8000. You can test the endpoints using a tool like postman or curl.
 
 ## API Endpoints
-|   HTTP Method     |   Endpoint    |   Description     |
-|-------------------|---------------|-------------------|
+The full API documentation is written using OpenAPI specifications on the endpoint `/docs`
+
+|   HTTP Method     | Endpoint      | Description                         |
+|-------------------|---------------|-------------------------------------|
+|   POST            | `/tasks`      | Creates a new task                  |
+|   GET             | `/tasks`      | Retrieves all tasks with pagination |
+|   GET             | `/tasks/:id`  | Retrieves a task by its ID          |
+|   PUT             | `/tasks/:id`  | Update an existing task by ID       |
+|   DELETE          | `/tasks/:id`  | Delete a task by ID                 |
 
 ## Error Handling
 The API provides descriptive error messages for common issues, such as:

--- a/src/main/java/task_management_system/docs/TaskPage.java
+++ b/src/main/java/task_management_system/docs/TaskPage.java
@@ -1,0 +1,21 @@
+package task_management_system.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import task_management_system.task.dto.TaskDto;
+
+import java.util.List;
+
+@Schema(name = "TaskPage", description = "Pagination tasks response")
+public class TaskPage extends PageImpl<TaskDto> {
+
+    public TaskPage(List<TaskDto> content) {
+        super(content, PageRequest.of(0, 10), content.size());
+    }
+
+    public TaskPage(List<TaskDto> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+}

--- a/src/main/java/task_management_system/dto/CustomResponse.java
+++ b/src/main/java/task_management_system/dto/CustomResponse.java
@@ -1,0 +1,7 @@
+package task_management_system.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CustomResponse(String status, String message) {
+}

--- a/src/main/java/task_management_system/dto/ValidationException.java
+++ b/src/main/java/task_management_system/dto/ValidationException.java
@@ -1,0 +1,9 @@
+package task_management_system.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+public record ValidationException(List<ValidationField> errors) {
+    @Builder
+    public record ValidationField (String field, String message) {}
+}

--- a/src/main/java/task_management_system/exception/BadRequestException.java
+++ b/src/main/java/task_management_system/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package task_management_system.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/task_management_system/exception/GlobalExceptionHandler.java
+++ b/src/main/java/task_management_system/exception/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package task_management_system.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import task_management_system.dto.CustomResponse;
+import task_management_system.dto.ValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public CustomResponse notFoundHandler(NotFoundException ex) {
+        return CustomResponse.builder()
+                .status("failure")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CustomResponse badRequestHandler(BadRequestException ex) {
+        return CustomResponse.builder()
+                .status("failure")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CustomResponse handleIllegalArg(IllegalArgumentException ex) {
+        return CustomResponse.builder()
+                .status("failure")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ValidationException InvalidArgumentHandler(MethodArgumentNotValidException ex) {
+        List<ValidationException.ValidationField> errors = new ArrayList<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            ValidationException.ValidationField field = ValidationException.ValidationField
+                    .builder()
+                    .field(error.getField())
+                    .message(error.getDefaultMessage())
+                    .build();
+
+            errors.add(field);
+        }
+        return new ValidationException(errors);
+    }
+}

--- a/src/main/java/task_management_system/exception/NotFoundException.java
+++ b/src/main/java/task_management_system/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package task_management_system.exception;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/task_management_system/task/controller/TaskController.java
+++ b/src/main/java/task_management_system/task/controller/TaskController.java
@@ -1,0 +1,176 @@
+package task_management_system.task.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import task_management_system.docs.TaskPage;
+import task_management_system.dto.ValidationException;
+import task_management_system.task.dto.CreateTaskRequest;
+import task_management_system.dto.CustomResponse;
+import task_management_system.task.dto.TaskDto;
+import task_management_system.task.dto.UpdateTask;
+import task_management_system.task.service.TaskService;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tasks")
+@Tag(name = "Task Controller", description = "Operations for managing tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201", description = "Task created successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = TaskDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "Invalid task data",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ValidationException.class)
+                    )
+            ),
+    })
+    @Operation(
+            summary = "Create a new task",
+            description = "Creates a new task for a user"
+    )
+    @PostMapping(consumes = "application/json", produces = "application/json")
+    public ResponseEntity<TaskDto> createTask(
+            @Parameter(description = "Task data to be created") @RequestBody @Valid CreateTaskRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(taskService.createTask(request));
+    }
+
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "Page of tasks",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = TaskPage.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "Invalid pagination parameters",
+                    content = @Content
+            ),
+    })
+    @Operation(
+            summary = "Get all tasks with pagination",
+            description = "Retrieves a paginated list of task with a default page size of 10."
+    )
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping(produces = "application/json")
+    public Page<TaskDto> getAllTasks(
+            @Parameter(description = "Page number (starting from 0)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "page size (default is 10)") @RequestParam(defaultValue = "10") int size) {
+        return taskService.getTasks(page, size);
+    }
+
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "Task retrieved successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = TaskDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "Task not found using the provided id",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
+    })
+    @Operation(
+            summary = "Get a task by its ID",
+            description = "Fetches a specific task by its unique ID."
+    )
+    @GetMapping(value = "/{taskID}", produces = "application/json")
+    public ResponseEntity<TaskDto> getTaskByID(
+            @Parameter(description = "Unique ID of task to retrieve") @PathVariable UUID taskID) {
+        return ResponseEntity.ok(taskService.getTaskByID(taskID));
+    }
+
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "Task update successful",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "Invalid task data",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ValidationException.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "Task not found",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
+    })
+    @Operation(
+            summary = "Update an existing task",
+            description = "Update a task's details for the given task ID"
+    )
+    @PutMapping(value = "/{taskID}", consumes = "application/json", produces = "application/json")
+    public ResponseEntity<CustomResponse> updateTask(
+            @Parameter(description = "Unique ID of the task") @PathVariable UUID taskID,
+            @Parameter(description = "Update task data") @RequestBody @Valid UpdateTask updateTask) {
+        return ResponseEntity.ok(taskService.updateTask(taskID, updateTask));
+    }
+
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "Task deleted",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "Task not found",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            )
+    })
+    @Operation(
+            summary = "Delete a task",
+            description = "Deletes the task with the specified ID"
+    )
+    @DeleteMapping(value = "/{taskID}", produces = "application/json")
+    public ResponseEntity<CustomResponse> deleteTask(
+            @Parameter(description = "Unique ID of the task") @PathVariable UUID taskID) {
+        return ResponseEntity.ok(taskService.deleteTask(taskID));
+    }
+}

--- a/src/main/java/task_management_system/task/dto/CreateTaskRequest.java
+++ b/src/main/java/task_management_system/task/dto/CreateTaskRequest.java
@@ -1,0 +1,37 @@
+package task_management_system.task.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Data;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
+
+import java.util.List;
+
+@Data
+@Builder
+public class CreateTaskRequest {
+
+    @NotBlank(message = "title is required")
+    private String title;
+
+    @NotBlank(message = "description is required")
+    private String description;
+
+    @NotBlank(message = "dueDate is required")
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}", message = "dueDate must be in the format yyyy-MM-dd'T'HH:mm:ss")
+    private String dueDate;
+
+    @NotNull(message = "status is required")
+    private TaskStatus status;
+
+    private TaskPriority priority;
+
+    @Email(message = "assignedTo must be a valid email")
+    private String assignedTo;
+
+    private List<String> tags;
+}

--- a/src/main/java/task_management_system/task/dto/TaskDto.java
+++ b/src/main/java/task_management_system/task/dto/TaskDto.java
@@ -1,0 +1,29 @@
+package task_management_system.task.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+public class TaskDto {
+
+    private UUID id;
+    private String title;
+    private String description;
+    private LocalDateTime dueDate;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private String assignedTo;
+    private List<String> tags;
+    private UUID createdBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/task_management_system/task/dto/UpdateTask.java
+++ b/src/main/java/task_management_system/task/dto/UpdateTask.java
@@ -1,0 +1,21 @@
+package task_management_system.task.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class UpdateTask {
+    private String title;
+    private String description;
+    private LocalDateTime dueDate;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private String assignedTo;
+    private List<String> tags;
+}

--- a/src/main/java/task_management_system/task/entity/Task.java
+++ b/src/main/java/task_management_system/task/entity/Task.java
@@ -1,0 +1,59 @@
+package task_management_system.task.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
+import task_management_system.user.entity.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "tasks")
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String title;
+
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime dueDate;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TaskStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private TaskPriority priority;
+
+    @Column
+    private String assignedTo;
+
+    @Column(name = "tag")
+    @ElementCollection
+    @CollectionTable(name = "task_tags", joinColumns = @JoinColumn(name = "task_id"))
+    private List<String> tags;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "created_by_id")
+    private User createdBy;
+}

--- a/src/main/java/task_management_system/task/enums/TaskPriority.java
+++ b/src/main/java/task_management_system/task/enums/TaskPriority.java
@@ -1,0 +1,7 @@
+package task_management_system.task.enums;
+
+public enum TaskPriority {
+    LOW,
+    MEDIUM,
+    HIGH,
+}

--- a/src/main/java/task_management_system/task/enums/TaskStatus.java
+++ b/src/main/java/task_management_system/task/enums/TaskStatus.java
@@ -1,0 +1,7 @@
+package task_management_system.task.enums;
+
+public enum TaskStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/task_management_system/task/repository/TaskRepository.java
+++ b/src/main/java/task_management_system/task/repository/TaskRepository.java
@@ -1,0 +1,10 @@
+package task_management_system.task.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import task_management_system.task.entity.Task;
+
+import java.util.UUID;
+
+public interface TaskRepository extends JpaRepository<Task, UUID> {
+
+}

--- a/src/main/java/task_management_system/task/service/TaskService.java
+++ b/src/main/java/task_management_system/task/service/TaskService.java
@@ -1,0 +1,122 @@
+package task_management_system.task.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import task_management_system.exception.BadRequestException;
+import task_management_system.exception.NotFoundException;
+import task_management_system.task.dto.CreateTaskRequest;
+import task_management_system.dto.CustomResponse;
+import task_management_system.task.dto.TaskDto;
+import task_management_system.task.dto.UpdateTask;
+import task_management_system.task.entity.Task;
+import task_management_system.task.repository.TaskRepository;
+
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    public TaskDto createTask(CreateTaskRequest taskRequest) {
+        LocalDateTime dueDate;
+        try {
+            dueDate = LocalDateTime.parse(taskRequest.getDueDate(), DATE_TIME_FORMATTER);
+        } catch (DateTimeException dte) {
+            throw new BadRequestException(dte.getMessage());
+        }
+
+        Task task = Task.builder()
+                .title(taskRequest.getTitle())
+                .description(taskRequest.getDescription())
+                .dueDate(dueDate)
+                .status(taskRequest.getStatus())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .priority(taskRequest.getPriority())
+                .assignedTo(taskRequest.getAssignedTo())
+                .tags(taskRequest.getTags())
+                .build();
+
+        taskRepository.saveAndFlush(task);
+        return convertToDo(task);
+    }
+
+    public TaskDto getTaskByID(UUID taskID) {
+        Task task = findTaskByID(taskID);
+        return convertToDo(task);
+    }
+
+    public Page<TaskDto> getTasks(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Task> tasks = taskRepository.findAll(pageable);
+
+        return tasks.map(this::convertToDo);
+    }
+
+    public CustomResponse updateTask(UUID taskID, UpdateTask updateRequest) {
+        Task task = findTaskByID(taskID);
+
+        task.setTitle(updateRequest.getTitle() != null
+                ? updateRequest.getTitle() : task.getTitle());
+        task.setDescription(updateRequest.getDescription() != null
+                ? updateRequest.getDescription() : task.getDescription());
+        task.setStatus(updateRequest.getStatus() != null
+                ? updateRequest.getStatus() : task.getStatus());
+        task.setDueDate(updateRequest.getDueDate() != null
+                ? updateRequest.getDueDate() : task.getDueDate());
+        task.setPriority(updateRequest.getPriority() != null
+                ? updateRequest.getPriority() : task.getPriority());
+        task.setAssignedTo(updateRequest.getDescription() != null
+                ? updateRequest.getAssignedTo() : task.getAssignedTo());
+        task.setTags(updateRequest.getTags() != null
+                ? updateRequest.getTags() : task.getTags());
+        task.setUpdatedAt(LocalDateTime.now());
+
+        taskRepository.save(task);
+
+        return CustomResponse.builder()
+                .status("success")
+                .message("Task with id: " + taskID + " updated")
+                .build();
+    }
+
+    public CustomResponse deleteTask(UUID taskID) {
+        Task task = findTaskByID(taskID);
+
+        taskRepository.delete(task);
+        return CustomResponse.builder()
+                .status("success")
+                .message("Task with id: " + taskID + " deleted")
+                .build();
+    }
+
+    private Task findTaskByID(UUID taskID) {
+        return taskRepository.findById(taskID)
+                .orElseThrow(() -> new NotFoundException("Task not found with id: " +  taskID));
+    }
+
+    private TaskDto convertToDo(Task task) {
+        return  TaskDto.builder()
+                .id(task.getId())
+                .title(task.getTitle())
+                .description(task.getDescription())
+                .status(task.getStatus())
+                .assignedTo(task.getAssignedTo())
+                .dueDate(task.getDueDate())
+                .tags(task.getTags())
+                .priority(task.getPriority())
+                .createdBy(null)
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/task_management_system/user/controller/UserController.java
+++ b/src/main/java/task_management_system/user/controller/UserController.java
@@ -1,0 +1,4 @@
+package task_management_system.user.controller;
+
+public class UserController {
+}

--- a/src/main/java/task_management_system/user/entity/User.java
+++ b/src/main/java/task_management_system/user/entity/User.java
@@ -1,0 +1,36 @@
+package task_management_system.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import task_management_system.task.entity.Task;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(unique = true)
+    private String username;
+
+    @Column
+    private String password;
+
+    @OneToMany(mappedBy = "createdBy", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Task> tasks;
+}

--- a/src/main/java/task_management_system/user/repository/UserRepository.java
+++ b/src/main/java/task_management_system/user/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package task_management_system.user.repository;
+
+public class UserRepository {
+}

--- a/src/main/java/task_management_system/user/service/UserService.java
+++ b/src/main/java/task_management_system/user/service/UserService.java
@@ -1,0 +1,4 @@
+package task_management_system.user.service;
+
+public class UserService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,5 +12,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.main.banner-mode=off
 
 # Swagger documentation
-springdoc.swagger-ui.path=/api/swagger-ui.html
+springdoc.swagger-ui.path=/docs
 springdoc.api-docs.path=/api/docs

--- a/src/test/java/task_management_system/task/controller/TaskControllerTest.java
+++ b/src/test/java/task_management_system/task/controller/TaskControllerTest.java
@@ -1,0 +1,33 @@
+package task_management_system.task.controller;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+
+class TaskControllerTest {
+
+    @Test
+    @Disabled("Not implemented yet")
+    void createTask() {
+    }
+
+    @Test
+    @Disabled("Not implemented")
+    void getAllTasks() {
+    }
+
+    @Test
+    @Disabled("Not implemented")
+    void getTaskByID() {
+    }
+
+    @Test
+    @Disabled("Not implemented")
+    void updateTask() {
+    }
+
+    @Test
+    @Disabled("Not implemented")
+    void deleteTask() {
+    }
+}

--- a/src/test/java/task_management_system/task/service/TaskServiceTest.java
+++ b/src/test/java/task_management_system/task/service/TaskServiceTest.java
@@ -1,0 +1,357 @@
+package task_management_system.task.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import task_management_system.dto.CustomResponse;
+import task_management_system.exception.BadRequestException;
+import task_management_system.exception.NotFoundException;
+import task_management_system.task.dto.CreateTaskRequest;
+import task_management_system.task.dto.TaskDto;
+import task_management_system.task.dto.UpdateTask;
+import task_management_system.task.entity.Task;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
+import task_management_system.task.repository.TaskRepository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+    @InjectMocks
+    private TaskService underTest;
+
+    private Task task;
+
+    @BeforeEach
+    void setup() {
+        List<String> tags = new ArrayList<>();
+        tags.add("setup-task");
+        tags.add("Testing");
+
+        task = Task.builder()
+                .id(UUID.randomUUID())
+                .title("Task title")
+                .description("Task description")
+                .status(TaskStatus.PENDING)
+                .dueDate(LocalDateTime.now())
+                .priority(TaskPriority.LOW)
+                .assignedTo("unkwnown@jondoe.com")
+                .tags(tags)
+                .createdAt(LocalDateTime.MIN)
+                .updatedAt(LocalDateTime.MIN)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Tests for Create Task")
+    class CreateTaskTest {
+        private CreateTaskRequest createRequest;
+
+        @BeforeEach
+        void setUpCreateTask() {
+            createRequest = CreateTaskRequest.builder()
+                    .title("Create Task Title")
+                    .description("Create Task description")
+                    .dueDate("2020-10-21T20:12:40")
+                    .status(TaskStatus.PENDING)
+                    .priority(TaskPriority.HIGH)
+                    .assignedTo("self@engineer-task.com")
+                    .tags(List.of("Create", "Task", "Test"))
+                    .build();
+        }
+
+        @Test
+        @DisplayName("should create a Task when all fields are provided")
+        void withAllFieldsProvided() {
+            UUID id = UUID.randomUUID();
+            when(taskRepository.saveAndFlush(any(Task.class))).thenAnswer(invocation -> {
+               Task newTask = invocation.getArgument(0);
+               newTask.setId(id);
+               return newTask;
+            });
+
+            TaskDto response = underTest.createTask(createRequest);
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+            verify(taskRepository, times(1)).saveAndFlush(taskCaptor.capture());
+
+            Task savedTask = taskCaptor.getValue();
+
+            // assert that the request data correct with saved data
+            assertEquals(createRequest.getTitle(), savedTask.getTitle());
+            assertEquals(createRequest.getDescription(), savedTask.getDescription());
+            assertEquals(createRequest.getTags(), savedTask.getTags());
+            assertEquals(createRequest.getStatus(), savedTask.getStatus());
+            assertEquals(createRequest.getPriority(), savedTask.getPriority());
+            assertEquals(createRequest.getAssignedTo(), savedTask.getAssignedTo());
+
+            // assert that the response data is correct
+            assertNotNull(response);
+            assertEquals(response.getId(), savedTask.getId());
+            assertEquals(response.getTitle(), savedTask.getTitle());
+            assertEquals(response.getDescription(), savedTask.getDescription());
+            assertEquals(response.getDueDate(), savedTask.getDueDate());
+            assertEquals(response.getTags(), savedTask.getTags());
+            assertEquals(response.getStatus(), savedTask.getStatus());
+            assertEquals(response.getPriority(), savedTask.getPriority());
+            assertEquals(response.getAssignedTo(), savedTask.getAssignedTo());
+            assertEquals(response.getCreatedAt(), savedTask.getCreatedAt());
+            assertEquals(response.getUpdatedAt(), savedTask.getUpdatedAt());
+        }
+
+        @Test
+        @DisplayName("should throw an exception when invalid dueDate format is passed")
+        void withInvalidDueDateFormat() {
+            createRequest.setDueDate("2024/11/21");
+
+            assertThrows(BadRequestException.class, () ->
+                    underTest.createTask(createRequest));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for getting Task by ID")
+    class GetTaskByIDTest {
+
+        @Test
+        @DisplayName("should successfully get task with valid taskID")
+        void withValidID() {
+            when(taskRepository.findById(task.getId())).thenReturn(Optional.of(task));
+
+            TaskDto response = underTest.getTaskByID(task.getId());
+
+            assertEquals(task.getId(), response.getId());
+            assertEquals(task.getTitle(), response.getTitle());
+            assertEquals(task.getStatus(), response.getStatus());
+            assertEquals(task.getDescription(), response.getDescription());
+            assertEquals(task.getTags(), response.getTags());
+            assertEquals(task.getPriority(), response.getPriority());
+            assertEquals(task.getCreatedAt(), response.getCreatedAt());
+            assertEquals(task.getAssignedTo(), response.getAssignedTo());
+            assertEquals(task.getDueDate(), response.getDueDate());
+            assertEquals(task.getUpdatedAt(), response.getUpdatedAt());
+
+            verify(taskRepository, times(1)).findById(task.getId());
+        }
+
+        @Test
+        @DisplayName("should throw exception when get task with invalid id")
+        void withInvalidID() {
+           Exception exception = assertThrows(NotFoundException.class, () -> underTest.getTaskByID(task.getId()));
+           assertEquals("Task not found with id: " +  task.getId(), exception.getMessage());
+
+           verify(taskRepository, times(1)).findById(task.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for getting all Tasks")
+    class GetAllTasksTest {
+
+        @Test
+        @DisplayName("should return list of tasks with valid page number")
+        void withValidPageNumber() {
+            int pageSize = 10;
+            int pageNumber = 0;
+            Pageable pageable = PageRequest.of(pageNumber, pageSize);
+
+            List<Task> tasks = Collections.singletonList(task);
+            Page<Task> taskPage = new PageImpl<>(tasks, pageable, tasks.size());
+
+            when(taskRepository.findAll(pageable)).thenReturn(taskPage);
+
+            Page<TaskDto> response = underTest.getTasks(pageNumber, pageSize);
+
+            assertEquals(1, response.getTotalPages(), "Expected one total page");
+            assertEquals(10, response.getSize(), "Expected page size of 10");
+            assertEquals(task.getId(), response.getContent().get(0).getId(), "Expects task ID to match");
+        }
+
+        @Test
+        @DisplayName("should return empty list with invalid page number")
+        void withInvalidPageNumber() {
+
+            int outOfRangePageNumber = 999;
+            int pageSize = 10;
+            Pageable pageable = PageRequest.of(outOfRangePageNumber, pageSize);
+
+            when(taskRepository.findAll(pageable)).thenReturn(Page.empty(pageable));
+
+            Page<TaskDto> result = underTest.getTasks(outOfRangePageNumber, pageSize);
+
+            assertTrue(result.isEmpty(), "Expected an empty page for an out-of-range page number");
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Tests for updating Tasks")
+    class UpdateTaskTest {
+
+        @Test
+        @DisplayName("should update a task when a valid id is provided")
+        void withValidID() {
+            UpdateTask request = UpdateTask.builder()
+                    .title("Update Title")
+                    .build();
+
+            when(taskRepository.findById(task.getId())).thenReturn(Optional.ofNullable(task));
+
+            assertEquals(task.getCreatedAt(), task.getUpdatedAt(),
+                    "expects the created and updated at to be equal before update");
+
+            String expectedMessage = "Task with id: " + task.getId() + " updated";
+            CustomResponse response = underTest.updateTask(task.getId(), request);
+
+            assertEquals("success", response.status(), "expects status to be 'success'");
+            assertEquals(expectedMessage, response.message(), "expects response message to match");
+            verify(taskRepository, times(1)).findById(task.getId());
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+            verify(taskRepository, times(1)).save(taskCaptor.capture());
+
+            Task savedTask = taskCaptor.getValue();
+            assertEquals(request.getTitle(), savedTask.getTitle(), "Expects title to be updated");
+            assertEquals(task.getDescription(), savedTask.getDescription(), "Expects description to be updated");
+            assertNotEquals(task.getCreatedAt(), task.getUpdatedAt(), "Expects updatedAt to be updated");
+        }
+
+        @Test
+        @DisplayName("should throw an exception when update with Invalid task id")
+        void withInvalidID() {
+            UUID invalidID = UUID.randomUUID();
+
+            Exception exception = assertThrows(NotFoundException.class, () ->
+                    underTest.getTaskByID(invalidID));
+            assertEquals("Task not found with id: " +  invalidID, exception.getMessage());
+
+            verify(taskRepository, times(1)).findById(invalidID);
+            verify(taskRepository, never()).save(any(Task.class));
+        }
+
+        @Test
+        @DisplayName("should update task with full fields provided")
+        void fullTaskUpdate() {
+            List<String> tags = task.getTags();
+            tags.add("new tag");
+
+            UpdateTask request = UpdateTask.builder()
+                    .title("Full update title")
+                    .description("Full update description")
+                    .status(TaskStatus.IN_PROGRESS)
+                    .dueDate(LocalDateTime.MAX)
+                    .priority(TaskPriority.MEDIUM)
+                    .assignedTo("newuser@assigned.com")
+                    .tags(tags)
+                    .build();
+
+            when(taskRepository.findById(task.getId())).thenReturn(Optional.of(task));
+
+            CustomResponse response = underTest.updateTask(task.getId(), request);
+
+            String expectedMessage = "Task with id: " + task.getId() + " updated";
+
+            // assert that response is correct
+            assertEquals("success", response.status(), "Expects status to be 'success'");
+            assertEquals(expectedMessage, response.message(), "Expects response message to match");
+            verify(taskRepository, times(1)).findById(task.getId());
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+            verify(taskRepository, times(1)).save(taskCaptor.capture());
+
+            Task savedTask = taskCaptor.getValue();
+
+            // assert that data is correctly saved
+            assertEquals(request.getTitle(), savedTask.getTitle(), "Expects title to be updated");
+            assertEquals(request.getDescription(), savedTask.getDescription(), "Expects description to be updated");
+            assertEquals(request.getStatus(), savedTask.getStatus(), "Expects status to be updated");
+            assertEquals(request.getPriority(), savedTask.getPriority(), "Expects priority to be updated");
+            assertEquals(request.getTags(), savedTask.getTags(), "Expects tags to be updated");
+            assertEquals(request.getDueDate(), savedTask.getDueDate(), "Expects dueDate to be updated");
+            assertEquals(request.getAssignedTo(), savedTask.getAssignedTo(),"Expects assignedTo to be updated");
+        }
+
+        @Test
+        @DisplayName("should partially update task")
+        void partialTaskUpdate() {
+            UpdateTask request = UpdateTask.builder()
+                    .status(TaskStatus.COMPLETED)
+                    .priority(TaskPriority.MEDIUM)
+                    .build();
+
+            when(taskRepository.findById(task.getId())).thenReturn(Optional.of(task));
+
+            CustomResponse response = underTest.updateTask(task.getId(), request);
+
+            String expectedMessage = "Task with id: " + task.getId() + " updated";
+
+            // assert that response is correct
+            assertEquals("success", response.status(), "Expects status to be 'success'");
+            assertEquals(expectedMessage, response.message(), "Expects response message to match");
+            verify(taskRepository, times(1)).findById(task.getId());
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+            verify(taskRepository, times(1)).save(taskCaptor.capture());
+
+            Task savedTask = taskCaptor.getValue();
+
+            // assert that data is correctly saved
+            assertEquals(request.getStatus(), savedTask.getStatus(), "Expects status to be updated");
+            assertEquals(request.getPriority(), savedTask.getPriority(), "Expects priority to be updated");
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Task Tests")
+    class DeleteTaskTests {
+
+        @Test
+        @DisplayName("should delete task with valid id")
+        void withValidID() {
+            when(taskRepository.findById(task.getId())).thenReturn(Optional.of(task));
+
+            CustomResponse response = underTest.deleteTask(task.getId());
+
+            String expectedMessage = "Task with id: " + task.getId() + " deleted";
+
+            assertEquals("success", response.status());
+            assertEquals(expectedMessage, response.message());
+
+            verify(taskRepository, times(1)).findById(task.getId());
+            verify(taskRepository, times(1)).delete(task);
+        }
+
+        @Test
+        @DisplayName("should throw exception when delete with invalid id")
+        void withInvalidID() {
+            UUID invalidID = UUID.randomUUID();
+
+            Exception exception = assertThrows(NotFoundException.class, () ->
+                    underTest.getTaskByID(invalidID));
+            assertEquals("Task not found with id: " +  invalidID, exception.getMessage());
+
+            verify(taskRepository, times(1)).findById(invalidID);
+            verify(taskRepository, never()).save(any(Task.class));
+        }
+    }
+
+}


### PR DESCRIPTION
**Description**
This PR implements the CRUD API according to issue #3 

**Endpoints**
- `POST /tasks` - allows user to create a task
- `GET /tasks` - allows user to get all tasks paginated to size of 10
- `GET /tasks/:id` - allows user to get a task by its id
- `PUT /tasks/:id` - allows user to update existing task by its id
- `DELETE /tasks/:id` - allows user to delete a task by its id

**Responses**
- `201 CREATED` - task created successfully
- `200 ok` - operation sucessful (get, put, get)
- `400 Bad Request` -  user sent invalid data (post, put)
- `404 Not Found` - Task not found with id supplied (get, put, delete)

**Documentation**
The documentation uses OpenAPI contract specification. To access the documentation
- follow the run instruction in the README.md
- access the documentation on the endpoint `/docs`

**Testing**
Unit tests is written to automate the task operation testing. To run the test on your terminal. 
```mvn clean test```

**Acceptance Criteria**
- [x] An api that allows users to create, read, update and delete tasks.
- [x] proper error handling
- [x] proper input validation
- [x] proper unit testing

closes #3 