### PR TITLE
feat: add authentication endpoints

### DIFF
--- a/.github/workflows/task_management_ci.yaml
+++ b/.github/workflows/task_management_ci.yaml
@@ -75,4 +75,5 @@ jobs:
           DATABASE_URL: mysql://localhost/${{ secrets.DATABASE }}
           DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
           DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,38 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/task_management_system/config/AppConfig.java
+++ b/src/main/java/task_management_system/config/AppConfig.java
@@ -30,7 +30,8 @@ public class AppConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
     }
 

--- a/src/main/java/task_management_system/config/AppConfig.java
+++ b/src/main/java/task_management_system/config/AppConfig.java
@@ -1,0 +1,46 @@
+package task_management_system.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import task_management_system.exception.NotFoundException;
+import task_management_system.user.repository.UserRepository;
+
+@Configuration
+@RequiredArgsConstructor
+public class AppConfig {
+
+    private final UserRepository userRepository;
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        return username -> userRepository.findByEmail(username)
+                .orElseThrow(() -> new NotFoundException("User not found"));
+    }
+
+    @Bean
+    BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+
+        return authProvider;
+    }
+}

--- a/src/main/java/task_management_system/config/DatabaseSeeder.java
+++ b/src/main/java/task_management_system/config/DatabaseSeeder.java
@@ -1,0 +1,117 @@
+package task_management_system.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import task_management_system.task.entity.Task;
+import task_management_system.task.entity.TaskRole;
+import task_management_system.task.enums.RoleType;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
+import task_management_system.task.repository.TaskRepository;
+import task_management_system.task.repository.TaskRoleRepository;
+import task_management_system.user.entity.User;
+import task_management_system.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DatabaseSeeder implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final TaskRepository taskRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${seed.password:password}")
+    private String password;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (isDatabaseEmpty()) {
+            seedDatabase();
+            log.info("Database seeded");
+        } else {
+            log.info("Database is not empty, skipping seeding.");
+        }
+    }
+
+    private boolean isDatabaseEmpty() {
+        return userRepository.count() == 0 &&
+                taskRepository.count() == 0;
+    }
+
+    private void seedDatabase() {
+        User user = User.builder()
+                .email("random@email.com")
+                .username("seed-user")
+                .password(passwordEncoder.encode(password))
+                .build();
+
+        User user2 = User.builder()
+                .email("seeded@user.com")
+                .username("seed-user2")
+                .password(passwordEncoder.encode(password))
+                .build();
+
+        userRepository.saveAllAndFlush(List.of(user, user2));
+
+        Task task1 = Task.builder()
+                .title("Seeded Task")
+                .description("Task created when application starts")
+                .createdBy(user)
+                .dueDate(LocalDateTime.now())
+                .tags(List.of("Test", "seeded data"))
+                .priority(TaskPriority.LOW)
+                .status(TaskStatus.IN_PROGRESS)
+                .build();
+
+        Task task2 = Task.builder()
+                .title("Seeded Task 2")
+                .description("Task created when application starts")
+                .createdBy(user2)
+                .dueDate(LocalDateTime.now().plusDays(10))
+                .tags(List.of("Test", "seeded data"))
+                .priority(TaskPriority.MEDIUM)
+                .status(TaskStatus.PENDING)
+                .build();
+
+        Task task3 = Task.builder()
+                .title("Seeded Task 3")
+                .description("Task created when application starts")
+                .createdBy(user)
+                .dueDate(LocalDateTime.now().plusDays(20))
+                .tags(List.of("Test", "seeded data"))
+                .priority(TaskPriority.MEDIUM)
+                .status(TaskStatus.PENDING)
+                .build();
+
+        Task task4 = Task.builder()
+                .title("Seeded Task 4")
+                .description("Task created when application starts")
+                .createdBy(user2)
+                .dueDate(LocalDateTime.now().plusDays(30))
+                .tags(List.of("Test", "seeded data"))
+                .priority(TaskPriority.LOW)
+                .status(TaskStatus.IN_PROGRESS)
+                .build();
+
+        Task task5 = Task.builder()
+                .title("Seeded Task 5")
+                .description("Task created when application starts")
+                .createdBy(user)
+                .dueDate(LocalDateTime.now())
+                .tags(List.of("Test", "seeded data"))
+                .priority(TaskPriority.MEDIUM)
+                .status(TaskStatus.COMPLETED)
+                .build();
+
+        taskRepository.saveAll(List.of(task1, task2, task3, task4, task5));
+    }
+}

--- a/src/main/java/task_management_system/config/JwtAuthFilter.java
+++ b/src/main/java/task_management_system/config/JwtAuthFilter.java
@@ -1,0 +1,64 @@
+package task_management_system.config;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String jwtToken = authHeader.split(" ")[1].trim();
+            String userEmail = jwtService.extractUsername(jwtToken);
+
+            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
+
+                if (jwtService.isTokenValid(jwtToken, userDetails)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+            filterChain.doFilter(request, response);
+        } catch (Exception ex) {
+            log.info("Unexpected error occurred during JWT token validation", ex);
+            handlerExceptionResolver.resolveException(request, response, null, ex);
+        }
+    }
+}

--- a/src/main/java/task_management_system/config/JwtService.java
+++ b/src/main/java/task_management_system/config/JwtService.java
@@ -1,0 +1,68 @@
+package task_management_system.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class JwtService {
+
+    private static final long JWT_TOKEN_VALID_TIME = TimeUnit.HOURS.toMillis(1);
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    public String extractUsername(String token) {
+        return getTokenPayloads(token).getSubject();
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        return Jwts.builder()
+                .subject(userDetails.getUsername())
+                .signWith(generateSigningKey())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(
+                        new Date(System.currentTimeMillis() +
+                        JWT_TOKEN_VALID_TIME)
+                )
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        String userEmail = getTokenPayloads(token).getSubject();
+
+        return userEmail.equals(userDetails.getUsername())
+                && !isTokenExpired(token);
+    }
+
+    public long getExpirationTime() {
+        return JWT_TOKEN_VALID_TIME;
+    }
+
+    private boolean isTokenExpired(String token) {
+        Date expirationDate =  getTokenPayloads(token)
+                .getExpiration();
+
+        return expirationDate.before(new Date());
+    }
+
+    private SecretKey generateSigningKey() {
+        byte[] keyInBytes = secret.getBytes();
+        return Keys.hmacShaKeyFor(keyInBytes);
+    }
+
+    private Claims getTokenPayloads(String token) {
+        return Jwts.parser()
+                .verifyWith(generateSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/task_management_system/config/SecurityConfig.java
+++ b/src/main/java/task_management_system/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable) // CSRF disabled because this is a stateless API using token-based authentication
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/users/**").permitAll()
                         .requestMatchers("/api/docs/**", "/docs/**", "/swagger-ui/**").permitAll()

--- a/src/main/java/task_management_system/config/SecurityConfig.java
+++ b/src/main/java/task_management_system/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package task_management_system.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final AuthenticationProvider authenticationProvider;
+    private final JwtAuthFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers("/users/**").permitAll()
+                        .requestMatchers("/api/docs/**", "/docs/**", "/swagger-ui/**").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowedOrigins(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**",configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/task_management_system/dto/ValidationException.java
+++ b/src/main/java/task_management_system/dto/ValidationException.java
@@ -1,9 +1,5 @@
 package task_management_system.dto;
 
-import lombok.Builder;
-import java.util.List;
+import java.util.HashMap;
 
-public record ValidationException(List<ValidationField> errors) {
-    @Builder
-    public record ValidationField (String field, String message) {}
-}
+public record ValidationException(HashMap<String, String> errors) {}

--- a/src/main/java/task_management_system/exception/ConflictException.java
+++ b/src/main/java/task_management_system/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package task_management_system.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/task_management_system/exception/ForbiddenException.java
+++ b/src/main/java/task_management_system/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package task_management_system.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/task_management_system/exception/GlobalExceptionHandler.java
+++ b/src/main/java/task_management_system/exception/GlobalExceptionHandler.java
@@ -1,60 +1,131 @@
 package task_management_system.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.AccountStatusException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import task_management_system.dto.CustomResponse;
 import task_management_system.dto.ValidationException;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.file.AccessDeniedException;
+import java.security.SignatureException;
+import java.util.HashMap;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public CustomResponse notFoundHandler(NotFoundException ex) {
-        return CustomResponse.builder()
-                .status("failure")
-                .message(ex.getMessage())
-                .build();
+        return setResponse("404", ex.getMessage());
     }
 
     @ExceptionHandler(BadRequestException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CustomResponse badRequestHandler(BadRequestException ex) {
-        return CustomResponse.builder()
-                .status("failure")
-                .message(ex.getMessage())
-                .build();
+        return setResponse("400", ex.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public CustomResponse handleIllegalArg(IllegalArgumentException ex) {
-        return CustomResponse.builder()
-                .status("failure")
-                .message(ex.getMessage())
-                .build();
+    public CustomResponse handleIllegalArgument(IllegalArgumentException ex) {
+        return setResponse("400", ex.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ValidationException InvalidArgumentHandler(MethodArgumentNotValidException ex) {
-        List<ValidationException.ValidationField> errors = new ArrayList<>();
-        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
-            ValidationException.ValidationField field = ValidationException.ValidationField
-                    .builder()
-                    .field(error.getField())
-                    .message(error.getDefaultMessage())
-                    .build();
+        HashMap<String, String> errors = new HashMap<>();
 
-            errors.add(field);
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
         }
+
         return new ValidationException(errors);
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public CustomResponse handleNoHandlerFound(NoHandlerFoundException ex) {
+        return setResponse("404", "Resource not found for route");
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public CustomResponse handleConflict(ConflictException ex) {
+        return setResponse(HttpStatus.CONFLICT.getReasonPhrase(), ex.getMessage());
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public CustomResponse handleBadCredentials(BadCredentialsException ex) {
+        return setResponse("401", "Invalid authentication credentials");
+    }
+
+    @ExceptionHandler(AccountStatusException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CustomResponse handleAccountStatus(AccountStatusException ex) {
+        return setResponse("403", "This account is locked");
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CustomResponse handleAccessDenied(AccessDeniedException ex) {
+        return setResponse("403", "You are not authorized to access this resource");
+    }
+
+    @ExceptionHandler(SignatureException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CustomResponse handleSignatureException(AccessDeniedException ex) {
+        return setResponse("403", "Invalid JWT token provided");
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CustomResponse handleExpiredJwt(ExpiredJwtException ex) {
+        return setResponse("403", "JWT token has expired");
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CustomResponse handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
+        return setResponse("400", ex.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CustomResponse handleHttpNotReadable(HttpMessageNotReadableException ex) {
+        return setResponse("400", ex.getMessage());
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CustomResponse handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        return setResponse("400", ex.getMessage());
+    }
+
+//    @ExceptionHandler(Exception.class)
+//    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+//    public CustomResponse handleSecurityException(Exception ex) {
+//        log.info(ex.getMessage());
+//        return setResponse("500", "Unknown internal server error");
+//    }
+
+    private CustomResponse setResponse(String status, String message) {
+        return CustomResponse.builder()
+                .status(status)
+                .message(message)
+                .build();
     }
 }

--- a/src/main/java/task_management_system/exception/GlobalExceptionHandler.java
+++ b/src/main/java/task_management_system/exception/GlobalExceptionHandler.java
@@ -115,12 +115,12 @@ public class GlobalExceptionHandler {
         return setResponse("400", ex.getMessage());
     }
 
-//    @ExceptionHandler(Exception.class)
-//    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-//    public CustomResponse handleSecurityException(Exception ex) {
-//        log.info(ex.getMessage());
-//        return setResponse("500", "Unknown internal server error");
-//    }
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public CustomResponse handleSecurityException(Exception ex) {
+        log.info(ex.getMessage());
+        return setResponse("500", "Unknown internal server error");
+    }
 
     private CustomResponse setResponse(String status, String message) {
         return CustomResponse.builder()

--- a/src/main/java/task_management_system/exception/NotFoundException.java
+++ b/src/main/java/task_management_system/exception/NotFoundException.java
@@ -1,6 +1,6 @@
 package task_management_system.exception;
 
-public class NotFoundException extends RuntimeException{
+public class NotFoundException extends RuntimeException {
     public NotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/task_management_system/exception/UnauthorizedException.java
+++ b/src/main/java/task_management_system/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package task_management_system.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/task_management_system/task/controller/TaskController.java
+++ b/src/main/java/task_management_system/task/controller/TaskController.java
@@ -46,6 +46,13 @@ public class TaskController {
                             schema = @Schema(implementation = ValidationException.class)
                     )
             ),
+            @ApiResponse(
+                    responseCode = "401", description = "Unauthenticated user trying to create task",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
     })
     @Operation(
             summary = "Create a new task",

--- a/src/main/java/task_management_system/task/dto/CreateTaskRequest.java
+++ b/src/main/java/task_management_system/task/dto/CreateTaskRequest.java
@@ -22,7 +22,10 @@ public class CreateTaskRequest {
     private String description;
 
     @NotBlank(message = "dueDate is required")
-    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}", message = "dueDate must be in the format yyyy-MM-dd'T'HH:mm:ss")
+    @Pattern(
+            regexp = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}",
+            message = "dueDate must be in the format yyyy-MM-ddTHH:mm:ss"
+    )
     private String dueDate;
 
     @NotNull(message = "status is required")

--- a/src/main/java/task_management_system/task/entity/Task.java
+++ b/src/main/java/task_management_system/task/entity/Task.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import task_management_system.task.enums.RoleType;
 import task_management_system.task.enums.TaskPriority;
 import task_management_system.task.enums.TaskStatus;
 import task_management_system.user.entity.User;
@@ -65,4 +66,20 @@ public class Task {
 
     @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<TaskRole> taskRoles = new HashSet<>();
+
+    @PrePersist
+    private void addCreatorRole() {
+        if (taskRoles == null) {
+            taskRoles = new HashSet<>();
+        }
+
+        if (createdBy != null) {
+            TaskRole creatorRole = TaskRole.builder()
+                    .task(this)
+                    .user(this.createdBy)
+                    .roleType(RoleType.CREATOR)
+                    .build();
+            taskRoles.add(creatorRole);
+        }
+    }
 }

--- a/src/main/java/task_management_system/task/entity/Task.java
+++ b/src/main/java/task_management_system/task/entity/Task.java
@@ -9,7 +9,9 @@ import task_management_system.task.enums.TaskStatus;
 import task_management_system.user.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -58,6 +60,9 @@ public class Task {
     private LocalDateTime updatedAt;
 
     @ManyToOne
-    @JoinColumn(name = "created_by_id")
+    @JoinColumn(name = "created_by_id", updatable = false)
     private User createdBy;
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<TaskRole> taskRoles = new HashSet<>();
 }

--- a/src/main/java/task_management_system/task/entity/Task.java
+++ b/src/main/java/task_management_system/task/entity/Task.java
@@ -2,6 +2,8 @@ package task_management_system.task.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import task_management_system.task.enums.TaskPriority;
 import task_management_system.task.enums.TaskStatus;
 import task_management_system.user.entity.User;
@@ -47,9 +49,11 @@ public class Task {
     @CollectionTable(name = "task_tags", joinColumns = @JoinColumn(name = "task_id"))
     private List<String> tags;
 
-    @Column(nullable = false)
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @UpdateTimestamp
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 

--- a/src/main/java/task_management_system/task/entity/TaskRole.java
+++ b/src/main/java/task_management_system/task/entity/TaskRole.java
@@ -1,0 +1,36 @@
+package task_management_system.task.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import task_management_system.task.enums.RoleType;
+import task_management_system.user.entity.User;
+
+@Getter
+@Setter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "task_roles",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames =
+                        { "task_id", "role_type" },
+                        name = "unique_task_creator"
+                )
+        }
+)
+public class TaskRole {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType roleType;
+
+    @ManyToOne
+    private User user;
+
+    @ManyToOne
+    private Task task;
+}

--- a/src/main/java/task_management_system/task/enums/RoleType.java
+++ b/src/main/java/task_management_system/task/enums/RoleType.java
@@ -1,0 +1,6 @@
+package task_management_system.task.enums;
+
+public enum RoleType {
+    CREATOR,
+    ASSIGNEE
+}

--- a/src/main/java/task_management_system/task/repository/TaskRepository.java
+++ b/src/main/java/task_management_system/task/repository/TaskRepository.java
@@ -1,10 +1,16 @@
 package task_management_system.task.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import task_management_system.task.entity.Task;
 
 import java.util.UUID;
 
 public interface TaskRepository extends JpaRepository<Task, UUID> {
 
+    @Query("SELECT t FROM Task t JOIN t.taskRoles tr WHERE tr.user.id = :userID")
+    Page<Task> findTasksByUserRoles(@Param("userID") UUID userID, Pageable pageable);
 }

--- a/src/main/java/task_management_system/task/repository/TaskRoleRepository.java
+++ b/src/main/java/task_management_system/task/repository/TaskRoleRepository.java
@@ -1,0 +1,14 @@
+package task_management_system.task.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import task_management_system.task.entity.Task;
+import task_management_system.task.entity.TaskRole;
+import task_management_system.user.entity.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TaskRoleRepository extends JpaRepository<TaskRole, Long> {
+    boolean existsByTaskIdAndUserId(UUID taskID, UUID userID);
+    Optional<TaskRole> findByTaskAndUser(Task task, User user);
+}

--- a/src/main/java/task_management_system/task/service/TaskService.java
+++ b/src/main/java/task_management_system/task/service/TaskService.java
@@ -5,14 +5,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import task_management_system.exception.BadRequestException;
+import task_management_system.exception.ForbiddenException;
 import task_management_system.exception.NotFoundException;
 import task_management_system.task.dto.CreateTaskRequest;
 import task_management_system.dto.CustomResponse;
 import task_management_system.task.dto.TaskDto;
 import task_management_system.task.dto.UpdateTask;
 import task_management_system.task.entity.Task;
+import task_management_system.task.entity.TaskRole;
+import task_management_system.task.enums.RoleType;
 import task_management_system.task.repository.TaskRepository;
+import task_management_system.task.repository.TaskRoleRepository;
+import task_management_system.user.entity.User;
+import task_management_system.utils.Utils;
 
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
@@ -24,10 +31,14 @@ import java.util.UUID;
 public class TaskService {
 
     private final TaskRepository taskRepository;
+    private final TaskRoleRepository taskRoleRepository;
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
+    @Transactional
     public TaskDto createTask(CreateTaskRequest taskRequest) {
+        User authUser = Utils.getAuthenticatedUser();
         LocalDateTime dueDate;
+
         try {
             dueDate = LocalDateTime.parse(taskRequest.getDueDate(), DATE_TIME_FORMATTER);
         } catch (DateTimeException dte) {
@@ -41,29 +52,59 @@ public class TaskService {
                 .status(taskRequest.getStatus())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
+                .createdBy(authUser)
                 .priority(taskRequest.getPriority())
                 .assignedTo(taskRequest.getAssignedTo())
                 .tags(taskRequest.getTags())
                 .build();
+
+        TaskRole role = TaskRole.builder()
+                .user(authUser)
+                .roleType(RoleType.CREATOR)
+                .build();
+
+        taskRoleRepository.save(role);
 
         taskRepository.saveAndFlush(task);
         return convertToDo(task);
     }
 
     public TaskDto getTaskByID(UUID taskID) {
-        Task task = findTaskByID(taskID);
+        User authUser = Utils.getAuthenticatedUser();
+        Task task = findTaskByID(taskID, authUser);
+
         return convertToDo(task);
     }
 
     public Page<TaskDto> getTasks(int page, int size) {
+        User authUser = Utils.getAuthenticatedUser();
+
         Pageable pageable = PageRequest.of(page, size);
-        Page<Task> tasks = taskRepository.findAll(pageable);
+        Page<Task> tasks = taskRepository.findTasksByUserRoles(
+                authUser.getId(),
+                pageable
+        );
 
         return tasks.map(this::convertToDo);
     }
 
     public CustomResponse updateTask(UUID taskID, UpdateTask updateRequest) {
-        Task task = findTaskByID(taskID);
+        User authUser = Utils.getAuthenticatedUser();
+        Task task = findTaskByID(taskID, authUser);
+
+        TaskRole role = taskRoleRepository.findByTaskAndUser(task, authUser)
+                .orElseThrow(() -> new ForbiddenException("user has no role on this task"));
+
+        if (!role.getRoleType().equals(RoleType.CREATOR)) {
+            if (updateRequest.getTitle() != null ||
+                    updateRequest.getDescription() != null ||
+                    updateRequest.getDueDate() != null ||
+                    updateRequest.getPriority() != null ||
+                    updateRequest.getAssignedTo() != null ||
+                    updateRequest.getTags() != null) {
+                throw new ForbiddenException("Only the status can be updated by assigned users.");
+            }
+        }
 
         task.setTitle(updateRequest.getTitle() != null
                 ? updateRequest.getTitle() : task.getTitle());
@@ -90,7 +131,16 @@ public class TaskService {
     }
 
     public CustomResponse deleteTask(UUID taskID) {
-        Task task = findTaskByID(taskID);
+        User authUser = Utils.getAuthenticatedUser();
+        Task task = findTaskByID(taskID, authUser);
+
+        TaskRole role = taskRoleRepository.findByTaskAndUser(task, authUser)
+                .orElseThrow();
+
+        boolean hasAuthority = role.getRoleType().equals(RoleType.CREATOR);
+        if (!hasAuthority) {
+            throw new ForbiddenException("only creator of task can delete task");
+        }
 
         taskRepository.delete(task);
         return CustomResponse.builder()
@@ -99,9 +149,20 @@ public class TaskService {
                 .build();
     }
 
-    private Task findTaskByID(UUID taskID) {
-        return taskRepository.findById(taskID)
+    private Task findTaskByID(UUID taskID, User authUser) {
+
+        Task task = taskRepository.findById(taskID)
                 .orElseThrow(() -> new NotFoundException("Task not found with id: " +  taskID));
+
+        boolean hasRole = taskRoleRepository.existsByTaskIdAndUserId(
+                taskID, authUser.getId()
+        );
+
+        if (!hasRole) {
+            throw new ForbiddenException("You are not authorized to access this resource");
+        }
+
+        return task;
     }
 
     private TaskDto convertToDo(Task task) {
@@ -114,7 +175,7 @@ public class TaskService {
                 .dueDate(task.getDueDate())
                 .tags(task.getTags())
                 .priority(task.getPriority())
-                .createdBy(null)
+                .createdBy(task.getCreatedBy().getId())
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
                 .build();

--- a/src/main/java/task_management_system/task/service/TaskService.java
+++ b/src/main/java/task_management_system/task/service/TaskService.java
@@ -41,6 +41,9 @@ public class TaskService {
 
         try {
             dueDate = LocalDateTime.parse(taskRequest.getDueDate(), DATE_TIME_FORMATTER);
+            if (dueDate.isBefore(LocalDateTime.now())) {
+                throw new BadRequestException("due date must be in the future to be valid");
+            }
         } catch (DateTimeException dte) {
             throw new BadRequestException(dte.getMessage());
         }
@@ -57,13 +60,6 @@ public class TaskService {
                 .assignedTo(taskRequest.getAssignedTo())
                 .tags(taskRequest.getTags())
                 .build();
-
-        TaskRole role = TaskRole.builder()
-                .user(authUser)
-                .roleType(RoleType.CREATOR)
-                .build();
-
-        taskRoleRepository.save(role);
 
         taskRepository.saveAndFlush(task);
         return convertToDo(task);
@@ -166,7 +162,7 @@ public class TaskService {
     }
 
     private TaskDto convertToDo(Task task) {
-        return  TaskDto.builder()
+        return TaskDto.builder()
                 .id(task.getId())
                 .title(task.getTitle())
                 .description(task.getDescription())

--- a/src/main/java/task_management_system/user/controller/UserController.java
+++ b/src/main/java/task_management_system/user/controller/UserController.java
@@ -1,4 +1,97 @@
 package task_management_system.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import task_management_system.dto.CustomResponse;
+import task_management_system.dto.ValidationException;
+import task_management_system.user.dto.CreateUserRequest;
+import task_management_system.user.dto.LoginRequest;
+import task_management_system.user.dto.LoginResponse;
+import task_management_system.user.dto.UserDto;
+import task_management_system.user.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+@Tag(name = "UserController", description = "Controller for managing user authentication")
 public class UserController {
+
+    private final UserService userService;
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201", description = "User created successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UserDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "User creation fails due to invalid data",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
+    })
+    @Operation(
+            summary = "Create a new user",
+            description = "A user is created using the details provided in the parameter"
+    )
+    @PostMapping(value = "/register", consumes = "application/json", produces = "application/json")
+    public ResponseEntity<UserDto> registerUser(
+            @Parameter(description = "Details used to create user") @RequestBody @Valid CreateUserRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(userService.registerUser(request));
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "User authenticated successfully",
+                    content =  @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LoginResponse.class)
+                    )
+            ),
+
+            @ApiResponse(
+                    responseCode = "400", description = "User trying to authenticate without providing need fields",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ValidationException.class)
+                    )
+            ),
+
+            @ApiResponse(
+                    responseCode = "401", description = "user authentication failed due to bad credentials",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomResponse.class)
+                    )
+            ),
+    })
+    @Operation(
+            summary = "Login/Authenticate User",
+            description = "Authenticates a user and generates a jwt token"
+    )
+    @PostMapping(value = "/login", consumes = "application/json", produces = "application/json")
+    public ResponseEntity<LoginResponse> loginUser(
+            @Parameter(description = "user data to use to process request") @RequestBody @Valid LoginRequest request) {
+        return ResponseEntity.ok(userService.authenticate(request));
+    }
 }

--- a/src/main/java/task_management_system/user/controller/UserController.java
+++ b/src/main/java/task_management_system/user/controller/UserController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/task_management_system/user/dto/CreateUserRequest.java
+++ b/src/main/java/task_management_system/user/dto/CreateUserRequest.java
@@ -1,0 +1,19 @@
+package task_management_system.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateUserRequest {
+    @NotBlank(message = "email is required")
+    @Email(message = "you need to provide a valid email")
+    private String email;
+
+    @NotBlank(message = "password is required")
+    private String password;
+
+    private String username;
+}

--- a/src/main/java/task_management_system/user/dto/CreateUserRequest.java
+++ b/src/main/java/task_management_system/user/dto/CreateUserRequest.java
@@ -2,16 +2,21 @@ package task_management_system.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class CreateUserRequest {
-    @NotBlank(message = "email is required")
     @Email(message = "you need to provide a valid email")
+    @NotBlank(message = "email is required")
     private String email;
 
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+            message = "Password must be at least 8 with one uppercase, lowercase, number and special character."
+    )
     @NotBlank(message = "password is required")
     private String password;
 

--- a/src/main/java/task_management_system/user/dto/LoginRequest.java
+++ b/src/main/java/task_management_system/user/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package task_management_system.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LoginRequest {
+
+        @NotBlank(message = "email is required for login")
+        private String email;
+
+        @NotBlank(message = "password is required for login")
+        private String password;
+}

--- a/src/main/java/task_management_system/user/dto/LoginResponse.java
+++ b/src/main/java/task_management_system/user/dto/LoginResponse.java
@@ -1,0 +1,9 @@
+package task_management_system.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponse(
+        TokenDto accessToken,
+        UserDto user
+) {}

--- a/src/main/java/task_management_system/user/dto/LoginResponse.java
+++ b/src/main/java/task_management_system/user/dto/LoginResponse.java
@@ -4,6 +4,5 @@ import lombok.Builder;
 
 @Builder
 public record LoginResponse(
-        TokenDto accessToken,
-        UserDto user
+        String accessToken
 ) {}

--- a/src/main/java/task_management_system/user/dto/TokenDto.java
+++ b/src/main/java/task_management_system/user/dto/TokenDto.java
@@ -1,0 +1,7 @@
+package task_management_system.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenDto(String token, long expiresIn) {
+}

--- a/src/main/java/task_management_system/user/dto/TokenDto.java
+++ b/src/main/java/task_management_system/user/dto/TokenDto.java
@@ -1,7 +1,0 @@
-package task_management_system.user.dto;
-
-import lombok.Builder;
-
-@Builder
-public record TokenDto(String token, long expiresIn) {
-}

--- a/src/main/java/task_management_system/user/dto/UserDto.java
+++ b/src/main/java/task_management_system/user/dto/UserDto.java
@@ -1,0 +1,16 @@
+package task_management_system.user.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record UserDto(
+        UUID userId,
+        String email,
+        String username,
+        boolean enabled,
+        boolean accountLocked,
+        boolean accountExpired
+) {}

--- a/src/main/java/task_management_system/user/dto/UserDto.java
+++ b/src/main/java/task_management_system/user/dto/UserDto.java
@@ -2,12 +2,11 @@ package task_management_system.user.dto;
 
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
 public record UserDto(
-        UUID userId,
+        UUID userID,
         String email,
         String username,
         boolean enabled,

--- a/src/main/java/task_management_system/user/entity/User.java
+++ b/src/main/java/task_management_system/user/entity/User.java
@@ -46,9 +46,19 @@ public class User implements UserDetails {
     @OneToMany(mappedBy = "createdBy", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Task> tasks;
 
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of();
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    public String getName() {
+        return username;
     }
 
     @Override

--- a/src/main/java/task_management_system/user/entity/User.java
+++ b/src/main/java/task_management_system/user/entity/User.java
@@ -1,22 +1,26 @@
 package task_management_system.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import task_management_system.task.entity.Task;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Setter
 @Entity
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "users")
-public class User {
+public class User implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -31,6 +35,39 @@ public class User {
     @Column
     private String password;
 
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
     @OneToMany(mappedBy = "createdBy", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Task> tasks;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
 }

--- a/src/main/java/task_management_system/user/repository/UserRepository.java
+++ b/src/main/java/task_management_system/user/repository/UserRepository.java
@@ -1,4 +1,12 @@
 package task_management_system.user.repository;
 
-public class UserRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import task_management_system.user.entity.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/task_management_system/user/service/UserService.java
+++ b/src/main/java/task_management_system/user/service/UserService.java
@@ -1,4 +1,90 @@
 package task_management_system.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import task_management_system.config.JwtService;
+import task_management_system.exception.BadRequestException;
+import task_management_system.user.dto.*;
+import task_management_system.user.entity.User;
+import task_management_system.user.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+
+    public UserDto registerUser(CreateUserRequest request) {
+        String hashedPassword = passwordEncoder.encode(request.getPassword());
+
+        // validate user does not exist already
+        userExist(
+                request.getEmail(),
+                request.getUsername()
+        );
+
+        User newUser = User.builder()
+                .email(request.getEmail())
+                .username(request.getUsername())
+                .password(hashedPassword)
+                .build();
+
+        userRepository.saveAndFlush(newUser);
+
+        return convertToDTO(newUser);
+    }
+
+    public LoginResponse authenticate(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BadCredentialsException("Invalid user Credential"));
+
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        request.getEmail(),
+                        request.getPassword()
+                )
+        );
+
+        TokenDto token = TokenDto.builder()
+                .token(jwtService.generateToken(user))
+                .expiresIn(jwtService.getExpirationTime())
+                .build();
+
+        return LoginResponse.builder()
+                .accessToken(token)
+                .user(convertToDTO(user))
+                .build();
+    }
+
+    private UserDto convertToDTO(User user) {
+        return UserDto.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .enabled(user.isEnabled())
+                .accountExpired(!user.isAccountNonExpired())
+                .accountLocked(!user.isAccountNonLocked())
+                .build();
+    }
+
+    private void userExist(String userEmail, String username) {
+        Optional<User> email = userRepository.findByEmail(userEmail);
+        Optional<User> name = userRepository.findByUsername(username);
+
+        if (email.isPresent()) {
+            throw new BadRequestException("user with email already exists");
+        }
+
+        if (name.isPresent()) {
+            throw new BadRequestException("user with username already exists");
+        }
+    }
 }

--- a/src/main/java/task_management_system/user/service/UserService.java
+++ b/src/main/java/task_management_system/user/service/UserService.java
@@ -26,10 +26,7 @@ public class UserService {
         String hashedPassword = passwordEncoder.encode(request.getPassword());
 
         // validate user does not exist already
-        userExist(
-                request.getEmail(),
-                request.getUsername()
-        );
+        userExist(request.getEmail(), request.getUsername());
 
         User newUser = User.builder()
                 .email(request.getEmail())
@@ -44,7 +41,7 @@ public class UserService {
 
     public LoginResponse authenticate(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BadCredentialsException("Invalid user Credential"));
+                .orElseThrow(() -> new BadCredentialsException("Invalid user credential"));
 
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
@@ -53,20 +50,16 @@ public class UserService {
                 )
         );
 
-        TokenDto token = TokenDto.builder()
-                .token(jwtService.generateToken(user))
-                .expiresIn(jwtService.getExpirationTime())
-                .build();
+        String token = jwtService.generateToken(user);
 
         return LoginResponse.builder()
                 .accessToken(token)
-                .user(convertToDTO(user))
                 .build();
     }
 
     private UserDto convertToDTO(User user) {
         return UserDto.builder()
-                .userId(user.getId())
+                .userID(user.getId())
                 .email(user.getEmail())
                 .username(user.getUsername())
                 .enabled(user.isEnabled())
@@ -83,7 +76,7 @@ public class UserService {
             throw new BadRequestException("user with email already exists");
         }
 
-        if (name.isPresent()) {
+        if (name.isPresent() && username != null) {
             throw new BadRequestException("user with username already exists");
         }
     }

--- a/src/main/java/task_management_system/user/service/UserService.java
+++ b/src/main/java/task_management_system/user/service/UserService.java
@@ -61,7 +61,7 @@ public class UserService {
         return UserDto.builder()
                 .userID(user.getId())
                 .email(user.getEmail())
-                .username(user.getUsername())
+                .username(user.getName())
                 .enabled(user.isEnabled())
                 .accountExpired(!user.isAccountNonExpired())
                 .accountLocked(!user.isAccountNonLocked())

--- a/src/main/java/task_management_system/utils/Utils.java
+++ b/src/main/java/task_management_system/utils/Utils.java
@@ -1,0 +1,21 @@
+package task_management_system.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import task_management_system.exception.UnauthorizedException;
+import task_management_system.user.entity.User;
+
+@Component
+@RequiredArgsConstructor
+public class Utils {
+
+    public static User getAuthenticatedUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth != null && auth.getPrincipal() instanceof User) {
+            return (User) auth.getPrincipal();
+        } throw new UnauthorizedException("user not authenticated");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,6 @@ jwt.secret=${JWT_SECRET}
 
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
+
+# seeded user password
+#seed.password=${PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ springdoc.swagger-ui.path=/docs
 springdoc.api-docs.path=/api/docs
 
 jwt.secret=${JWT_SECRET}
+
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ spring.main.banner-mode=off
 # Swagger documentation
 springdoc.swagger-ui.path=/docs
 springdoc.api-docs.path=/api/docs
+
+jwt.secret=${JWT_SECRET}

--- a/src/test/java/task_management_system/task/controller/TaskControllerTest.java
+++ b/src/test/java/task_management_system/task/controller/TaskControllerTest.java
@@ -2,9 +2,34 @@ package task_management_system.task.controller;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import task_management_system.config.JwtService;
+import task_management_system.task.service.TaskService;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@WebMvcTest(TaskController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockitoExtension.class)
 class TaskControllerTest {
+
+    @MockBean
+    private TaskService taskService;
+    @MockBean
+    private JwtService jwtService;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldCreateMockMvc() {
+        assertNotNull(mockMvc);
+    }
 
     @Test
     @Disabled("Not implemented yet")

--- a/src/test/java/task_management_system/task/controller/TaskControllerTest.java
+++ b/src/test/java/task_management_system/task/controller/TaskControllerTest.java
@@ -1,18 +1,31 @@
 package task_management_system.task.controller;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import task_management_system.config.JwtService;
+import task_management_system.task.dto.CreateTaskRequest;
+import task_management_system.task.enums.TaskPriority;
+import task_management_system.task.enums.TaskStatus;
 import task_management_system.task.service.TaskService;
+import task_management_system.user.entity.User;
+
+import java.util.Collections;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TaskController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -26,14 +39,67 @@ class TaskControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+    }
+
     @Test
     void shouldCreateMockMvc() {
         assertNotNull(mockMvc);
     }
 
-    @Test
-    @Disabled("Not implemented yet")
-    void createTask() {
+    @Nested
+    @DisplayName("Create Task Controller Tests")
+    class CreateTaskTests {
+
+        private CreateTaskRequest createRequest;
+
+        @BeforeEach
+        void setUpCreateTask() {
+            createRequest = CreateTaskRequest.builder()
+                    .title("Test Task Title")
+                    .description("Test Task description")
+                    .status(TaskStatus.PENDING)
+                    .priority(TaskPriority.LOW)
+                    .assignedTo("john@doe.com")
+                    .tags(Collections.singletonList("Test"))
+                    .dueDate("2024-11-21T14:20:10")
+                    .build();
+        }
+
+        @Test
+        @WithMockUser
+        @Disabled
+        @DisplayName("should create task successfully")
+        void createTask() throws Exception {
+            String request = objectMapper.writeValueAsString(createRequest);
+
+            User mockUser = User.builder()
+                    .id(UUID.randomUUID())
+                    .username("mock-user")
+                    .email("mock@user.com")
+                    .build();
+
+
+            mockMvc.perform(post("/tasks")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isCreated())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.title").value(createRequest.getTitle()))
+                    .andExpect(jsonPath("$.description").value(createRequest.getDescription()))
+                    .andExpect(jsonPath("$.dueDate").value(createRequest.getDueDate()))
+                    .andExpect(jsonPath("$.tag").value(createRequest.getTags()))
+                    .andExpect(jsonPath("$.status").value(createRequest.getStatus()))
+                    .andExpect(jsonPath("$.priority").value(createRequest.getPriority()))
+                    .andExpect(jsonPath("$.assignedTo").value(createRequest.getAssignedTo()))
+                    .andExpect(jsonPath("$.createdBy").exists())
+                    .andExpect(jsonPath("$.createdAt").isNotEmpty())
+                    .andExpect(jsonPath("$.updatedAt").isNotEmpty());
+        }
     }
 
     @Test

--- a/src/test/java/task_management_system/task/controller/TaskControllerTest.java
+++ b/src/test/java/task_management_system/task/controller/TaskControllerTest.java
@@ -15,15 +15,18 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import task_management_system.config.JwtService;
 import task_management_system.task.dto.CreateTaskRequest;
+import task_management_system.task.dto.TaskDto;
 import task_management_system.task.enums.TaskPriority;
 import task_management_system.task.enums.TaskStatus;
 import task_management_system.task.service.TaskService;
 import task_management_system.user.entity.User;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -38,7 +41,6 @@ class TaskControllerTest {
     private JwtService jwtService;
     @Autowired
     private MockMvc mockMvc;
-
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -56,6 +58,7 @@ class TaskControllerTest {
     class CreateTaskTests {
 
         private CreateTaskRequest createRequest;
+        private TaskDto taskDto;
 
         @BeforeEach
         void setUpCreateTask() {
@@ -68,21 +71,29 @@ class TaskControllerTest {
                     .tags(Collections.singletonList("Test"))
                     .dueDate("2024-11-21T14:20:10")
                     .build();
+
+            taskDto = TaskDto.builder()
+                    .id(UUID.randomUUID())
+                    .title(createRequest.getTitle())
+                    .description(createRequest.getDescription())
+                    .dueDate(LocalDateTime.parse(createRequest.getDueDate()))
+                    .createdBy(UUID.randomUUID())
+                    .status(createRequest.getStatus())
+                    .priority(createRequest.getPriority())
+                    .assignedTo(createRequest.getAssignedTo())
+                    .tags(createRequest.getTags())
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
         }
 
         @Test
         @WithMockUser
-        @Disabled
         @DisplayName("should create task successfully")
         void createTask() throws Exception {
             String request = objectMapper.writeValueAsString(createRequest);
 
-            User mockUser = User.builder()
-                    .id(UUID.randomUUID())
-                    .username("mock-user")
-                    .email("mock@user.com")
-                    .build();
-
+            when(taskService.createTask(createRequest)).thenReturn(taskDto);
 
             mockMvc.perform(post("/tasks")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -92,13 +103,23 @@ class TaskControllerTest {
                     .andExpect(jsonPath("$.title").value(createRequest.getTitle()))
                     .andExpect(jsonPath("$.description").value(createRequest.getDescription()))
                     .andExpect(jsonPath("$.dueDate").value(createRequest.getDueDate()))
-                    .andExpect(jsonPath("$.tag").value(createRequest.getTags()))
-                    .andExpect(jsonPath("$.status").value(createRequest.getStatus()))
-                    .andExpect(jsonPath("$.priority").value(createRequest.getPriority()))
+                    .andExpect(jsonPath("$.status").value(createRequest.getStatus().toString()))
+                    .andExpect(jsonPath("$.priority").value(createRequest.getPriority().toString()))
                     .andExpect(jsonPath("$.assignedTo").value(createRequest.getAssignedTo()))
                     .andExpect(jsonPath("$.createdBy").exists())
                     .andExpect(jsonPath("$.createdAt").isNotEmpty())
                     .andExpect(jsonPath("$.updatedAt").isNotEmpty());
+        }
+
+        @Test
+        @WithMockUser
+        @Disabled("Not implemented")
+        void createTaskBadRequest() {
+        }
+
+        @Test
+        @Disabled("Not implemented")
+        void createTaskUnauthenticated() {
         }
     }
 

--- a/src/test/java/task_management_system/task/service/TaskServiceTest.java
+++ b/src/test/java/task_management_system/task/service/TaskServiceTest.java
@@ -87,7 +87,7 @@ class TaskServiceTest {
             createRequest = CreateTaskRequest.builder()
                     .title("Create Task Title")
                     .description("Create Task description")
-                    .dueDate("2020-10-21T20:12:40")
+                    .dueDate("2100-10-21T20:12:40")
                     .status(TaskStatus.PENDING)
                     .priority(TaskPriority.HIGH)
                     .assignedTo("self@engineer-task.com")

--- a/src/test/java/task_management_system/user/controller/UserControllerTest.java
+++ b/src/test/java/task_management_system/user/controller/UserControllerTest.java
@@ -1,0 +1,211 @@
+package task_management_system.user.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.web.servlet.MockMvc;
+import task_management_system.config.JwtService;
+import task_management_system.user.dto.CreateUserRequest;
+import task_management_system.user.dto.LoginRequest;
+import task_management_system.user.dto.LoginResponse;
+import task_management_system.user.dto.UserDto;
+import task_management_system.user.service.UserService;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockBean private UserService userService;
+    @MockBean private JwtService jwtService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void shouldCreateMockMvc() {
+        assertNotNull(mockMvc, "should create mock mvc");
+    }
+
+    @Nested
+    @DisplayName("User Registration Controller Test")
+    class RegisterUserTest {
+
+        private CreateUserRequest userRequest;
+
+        @BeforeEach
+        void setUpRegisterUser() {
+            userRequest = CreateUserRequest.builder().build();
+        }
+
+        @Test
+        @DisplayName("should not register user when no data is provided")
+        void registerUserWithNoData() throws Exception {
+            String requestString = objectMapper.writeValueAsString(userRequest);
+
+            mockMvc.perform(post("/users/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errors.email").value("email is required"))
+                    .andExpect(jsonPath("$.errors.password").value("password is required"));
+        }
+
+        @Test
+        @DisplayName("should not register user when invalid email is provided")
+        void registerUserWithInvalidEmail() throws Exception {
+            userRequest.setEmail("invalid-email");
+            userRequest.setPassword("P@sswarD-cu3d");
+            String requestString = objectMapper.writeValueAsString(userRequest);
+
+            mockMvc.perform(post("/users/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errors.email").value("you need to provide a valid email"));
+        }
+
+        @Test
+        @DisplayName("should not register user when invalid password is provided")
+        void registerUserWithInvalidPassword() throws Exception {
+            userRequest.setEmail("user@email.com");
+            userRequest.setPassword("invalid-password");
+
+            String requestString = objectMapper.writeValueAsString(userRequest);
+
+            mockMvc.perform(post("/users/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errors.password").value(
+                            "Password must be at least 8 with one uppercase, lowercase, number and special character."));
+        }
+
+        @Test
+        @DisplayName("should register user successfully")
+        void registerData() throws Exception {
+
+           userRequest.setEmail("johndoe@unknown.com");
+           userRequest.setPassword("p@ssUs3r93t");
+           userRequest.setUsername("username");
+
+            UserDto response = UserDto.builder()
+                    .userID(UUID.randomUUID())
+                    .email(userRequest.getEmail())
+                    .username(userRequest.getUsername())
+                    .enabled(true)
+                    .accountLocked(false)
+                    .accountExpired(false)
+                    .build();
+
+            when(userService.registerUser(userRequest)).thenReturn(response);
+
+            String requestString = objectMapper.writeValueAsString(userRequest);
+
+            mockMvc.perform(post("/users/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isCreated())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.email").value(response.email()))
+                    .andExpect(jsonPath("$.username").value(response.username()))
+                    .andExpect(jsonPath("$.userID").value(response.userID().toString()))
+                    .andExpect(jsonPath("$.enabled").value(response.enabled()))
+                    .andExpect(jsonPath("$.accountLocked").value(response.accountLocked()))
+                    .andExpect(jsonPath("$.accountExpired").value(response.accountExpired()));
+        }
+    }
+
+    @Nested
+    @DisplayName("User Authentication Controller Test")
+    class LoginUserTest {
+
+        private LoginRequest loginRequest;
+
+        @BeforeEach
+        void setupLoginUser() {
+            loginRequest = LoginRequest.builder()
+                    .email("user@email.com")
+                    .password("P@ssw0rd222")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("should successfully login user")
+        void shouldLoginUser() throws Exception {
+
+            LoginResponse response = LoginResponse.builder()
+                    .accessToken("dummy-access-token")
+                    .build();
+
+            when(userService.authenticate(loginRequest)).thenReturn(response);
+
+            String requestString = objectMapper.writeValueAsString(loginRequest);
+
+            mockMvc.perform(post("/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.accessToken").value(response.accessToken()));
+        }
+
+        @Test
+        @DisplayName("should not process request with invalid data")
+        void loginUserWithNoData() throws Exception {
+            loginRequest = LoginRequest.builder().build();
+
+            String requestString = objectMapper.writeValueAsString(loginRequest);
+
+            mockMvc.perform(post("/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errors.email").value("email is required for login"))
+                    .andExpect(jsonPath("$.errors.password").value("password is required for login"));
+        }
+
+        @Test
+        @DisplayName("should not authenticate request with invalid credential")
+        void loginUserWithInvalidCredential() throws Exception {
+            String requestString = objectMapper.writeValueAsString(loginRequest);
+
+            when(userService.authenticate(loginRequest)).thenThrow(BadCredentialsException.class);
+
+            mockMvc.perform(post("/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestString))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.status").value("401"))
+                    .andExpect(jsonPath("$.message").value("Invalid authentication credentials"));
+        }
+    }
+}

--- a/src/test/java/task_management_system/user/service/UserServiceTest.java
+++ b/src/test/java/task_management_system/user/service/UserServiceTest.java
@@ -1,0 +1,226 @@
+package task_management_system.user.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import task_management_system.config.JwtService;
+import task_management_system.exception.BadRequestException;
+import task_management_system.user.dto.CreateUserRequest;
+import task_management_system.user.dto.LoginRequest;
+import task_management_system.user.dto.LoginResponse;
+import task_management_system.user.dto.UserDto;
+import task_management_system.user.entity.User;
+import task_management_system.user.repository.UserRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private JwtService jwtService;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private AuthenticationManager authManager;
+    @InjectMocks private UserService underTest;
+
+    private User user;
+
+    @BeforeEach
+    void setup() {
+        user = User.builder()
+                .id(UUID.randomUUID())
+                .password("encoded-password")
+                .email("john@doe.com")
+                .username("john-doe")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("User Registration Tests")
+    class RegisterUserTest {
+
+        private CreateUserRequest request;
+        private User registerUser;
+
+        @BeforeEach
+        void setUpRegisterUser() {
+            request = CreateUserRequest.builder()
+                    .password("password")
+                    .email("register@user.com")
+                    .build();
+
+            registerUser = User.builder()
+                    .id(UUID.randomUUID())
+                    .email(request.getEmail())
+                    .password("encoded-password")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("should register user successfully Without username field")
+        void registerUser() {
+            when(passwordEncoder.encode(request.getPassword())).thenReturn("encoded-password");
+            when(userRepository.saveAndFlush(any(User.class))).then(invocation -> registerUser);
+            when(userRepository.findByUsername(null)).thenReturn(Optional.of(registerUser));
+
+            UserDto response = underTest.registerUser(request);
+
+            ArgumentCaptor<User> userArgumentCaptor = ArgumentCaptor.forClass(User.class);
+
+            verify(userRepository).saveAndFlush(userArgumentCaptor.capture());
+            User capturedUser = userArgumentCaptor.getValue();
+
+            assertEquals(capturedUser.getId(), response.userID(), "Expects response userID to be same as captured UserID");
+            assertEquals(capturedUser.getEmail(), response.email(), "Expects captured email to be same as response email");
+            assertNull(capturedUser.getUsername(), "Expects no username in the captured data as it's no provided");
+            assertEquals(capturedUser.getPassword(), "encoded-password", "Expects captured password to be encoded");
+
+            // validate the response
+            assertEquals(response.email(), registerUser.getEmail(), "Expects response email to be same as register email");
+            assertNull(response.username(), "Expects response username to be null as it's not provided");
+            assertTrue(response.enabled(), "Expects user to be enabled");
+            assertFalse(response.accountExpired(), "Expects user account to not be expired");
+            assertFalse(response.accountLocked(), "Expects user account not to be locked");
+        }
+
+        @Test
+        @DisplayName("should register user with username")
+        void registerUserWithUsername() {
+            request.setUsername("john-doe");
+            registerUser.setUsername("john-doe");
+
+            when(passwordEncoder.encode(request.getPassword())).thenReturn("encoded-password");
+            when(userRepository.saveAndFlush(any(User.class))).then(invocation -> registerUser);
+
+            UserDto response = underTest.registerUser(request);
+
+            ArgumentCaptor<User> userArgumentCaptor = ArgumentCaptor.forClass(User.class);
+
+            verify(userRepository).saveAndFlush(userArgumentCaptor.capture());
+            User capturedUser = userArgumentCaptor.getValue();
+
+            assertEquals(capturedUser.getId(), response.userID(), "Expects response userID to be same as captured UserID");
+            assertEquals(capturedUser.getEmail(), response.email(), "Expects captured email to be same as response email");
+            assertEquals(capturedUser.getUsername(), response.username(), "Expects no username in the captured data as it's no provided");
+            assertEquals(capturedUser.getPassword(), "encoded-password", "Expects captured password to be encoded");
+
+            // validate the response
+            assertEquals(response.email(), registerUser.getEmail(), "Expects response email to be same as register email");
+            assertEquals(response.username(),  "john-doe", "Expects response username to be null as it's not provided");
+            assertTrue(response.enabled(), "Expects user to be enabled");
+            assertFalse(response.accountExpired(), "Expects user account to not be expired");
+            assertFalse(response.accountLocked(), "Expects user account not to be locked");
+        }
+
+        @Test
+        @DisplayName("should throw an exception when username already exist")
+        void registerUserWithExistingUsername() {
+            request.setUsername("username");
+            registerUser.setUsername("username");
+
+            when(userRepository.findByUsername(request.getUsername()))
+                    .thenReturn(Optional.of(registerUser));
+
+            Exception ex = assertThrows(BadRequestException.class, () ->
+                    underTest.registerUser(request));
+
+            assertEquals("user with username already exists", ex.getMessage());
+            verify(userRepository, never()).saveAndFlush(any(User.class));
+        }
+
+        @Test
+        @DisplayName("should throw an exception when email already exist")
+        void registerUserWithExistingEmail() {
+            when(userRepository.findByEmail(request.getEmail()))
+                    .thenReturn(Optional.of(registerUser));
+
+            Exception ex = assertThrows(BadRequestException.class, () ->
+                    underTest.registerUser(request));
+
+            assertEquals("user with email already exists", ex.getMessage());
+            verify(userRepository, never()).saveAndFlush(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("User Authentication Tests")
+    class LoginUserTest {
+
+        private LoginRequest request;
+
+        @BeforeEach
+        void setup() {
+            request = LoginRequest.builder()
+                    .email(user.getEmail())
+                    .password(user.getPassword())
+                    .build();
+        }
+
+        @Test
+        @DisplayName("should successfully authenticate valid user")
+        void shouldAuthenticateUser() {
+            String token = "dummy-jwt-token-string";
+
+            when(jwtService.generateToken(user)).thenReturn(token);
+            when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+
+            LoginResponse response = underTest.authenticate(request);
+
+            assertEquals(response.accessToken(), token);
+
+            verify(userRepository, times(1)).findByEmail(request.getEmail());
+            verify(jwtService, times(1)).generateToken(user);
+            verify(authManager).authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+            );
+        }
+
+        @Test
+        @DisplayName("Should throw BadCredentialsException when user is not found")
+        void authenticateWithInvalidEmail() {
+            // Arrange
+            when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+
+            // Act & Assert
+            Exception ex = assertThrows(BadCredentialsException.class,
+                    () -> underTest.authenticate(request));
+
+            assertEquals("Invalid user credential", ex.getMessage());
+
+            verify(authManager, never()).authenticate(any(UsernamePasswordAuthenticationToken.class));
+            verify(jwtService, never()).generateToken(any(User.class));
+        }
+
+        @Test
+        @DisplayName("Should throw BadCredentialsException for invalid credentials")
+        void authenticateWithInvalidPassword() {
+            // Arrange
+            when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+            doThrow(new BadCredentialsException("Invalid credentials"))
+                    .when(authManager)
+                    .authenticate(any(UsernamePasswordAuthenticationToken.class));
+
+            // Act & Assert
+            assertThrows(BadCredentialsException.class, () -> underTest.authenticate(request));
+
+            verify(authManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+            verify(jwtService, never()).generateToken(any(User.class));
+        }
+    }
+
+}

--- a/src/test/java/task_management_system/user/service/UserServiceTest.java
+++ b/src/test/java/task_management_system/user/service/UserServiceTest.java
@@ -87,7 +87,7 @@ class UserServiceTest {
 
             assertEquals(capturedUser.getId(), response.userID(), "Expects response userID to be same as captured UserID");
             assertEquals(capturedUser.getEmail(), response.email(), "Expects captured email to be same as response email");
-            assertNull(capturedUser.getUsername(), "Expects no username in the captured data as it's no provided");
+            assertNull(capturedUser.getName(), "Expects no username in the captured data as it's no provided");
             assertEquals(capturedUser.getPassword(), "encoded-password", "Expects captured password to be encoded");
 
             // validate the response
@@ -116,7 +116,7 @@ class UserServiceTest {
 
             assertEquals(capturedUser.getId(), response.userID(), "Expects response userID to be same as captured UserID");
             assertEquals(capturedUser.getEmail(), response.email(), "Expects captured email to be same as response email");
-            assertEquals(capturedUser.getUsername(), response.username(), "Expects no username in the captured data as it's no provided");
+            assertEquals(capturedUser.getName(), response.username(), "Expects no username in the captured data as it's no provided");
             assertEquals(capturedUser.getPassword(), "encoded-password", "Expects captured password to be encoded");
 
             // validate the response


### PR DESCRIPTION
**Description**
This PR implements the authentication tasks in reference to issue #5 

**Task Completed**
- added spring security
- configured jwt authentication
- allow user to register

**Endpoints**
-` POST /users/register`: Register a new user.
- `POST /users/login`: Authenticate an existing user and generate a JWT token.

**Responses**
- 200 - successful authentication
- 201 - successful user registration
- 400 - invalid user request
- 401 - invalid user authentication credential

**Acceptable Criteria**
- [x] A new user can register using the endpoint `POST /users/register`
- [x] Existing users can authenticate using the endpoint `POST /users/login`
- [x] Only authenticated user can access a task
- [x] user can only access tasks they created or are assigned to.
- [x] Properly error handling including error message and code
- [x] Proper Data validation before processing to ensure data integrity

closes #5 